### PR TITLE
Add resolve animation and dice border

### DIFF
--- a/GameScene.js
+++ b/GameScene.js
@@ -14,6 +14,7 @@ export class GameScene extends Phaser.Scene {
         this.playerMaxHealth = 100;
         this.playerHealth = this.playerMaxHealth;
         this.healthBar = null;
+        this.isResolving = false;
     }
     
     preload() {
@@ -122,15 +123,22 @@ export class GameScene extends Phaser.Scene {
     }
 
     resolveDice() {
+        if (this.isResolving) {
+            return;
+        }
+        this.isResolving = true;
+
+        this.disableAllInputs();
+
         // Play resolve sound effect
         this.sound.play('chimeShort', { volume: 0.7 });
         this.sound.play('chimeLong', {
             volume: 0.4,
-            seek: 1.5,     // start 0.5s into the clip
-            duration: 1, // play for 1 second
-            rate: 3      // 1.0 = normal speed, >1 = faster, <1 = slower
+            seek: 1.5,
+            duration: 1,
+            rate: 3
         });
-        
+
         // Calculate scores
         const defendType = evaluateCombo(this.defendDice).type;
         const attackType = evaluateCombo(this.attackDice).type;
@@ -140,27 +148,126 @@ export class GameScene extends Phaser.Scene {
         const attackSummation = this.attackDice.reduce((sum, die) => sum + die.value, 0);
         const defendScore = defendSummation + defendBonus;
         const attackScore = attackSummation + attackBonus;
-        
+
         // Update or create score text
         if (!this.defendText) {
-            this.defendText = this.add.text(200, CONSTANTS.RESOLVE_TEXT_Y, "", { 
-                fontSize: "28px", 
-                color: "#3498db" 
+            this.defendText = this.add.text(200, CONSTANTS.RESOLVE_TEXT_Y, "", {
+                fontSize: "28px",
+                color: "#3498db"
             }).setOrigin(0.5);
-            
-            this.attackText = this.add.text(600, CONSTANTS.RESOLVE_TEXT_Y, "", { 
-                fontSize: "28px", 
-                color: "#e74c3c" 
+
+            this.attackText = this.add.text(600, CONSTANTS.RESOLVE_TEXT_Y, "", {
+                fontSize: "28px",
+                color: "#e74c3c"
             }).setOrigin(0.5);
         }
-        
+
         this.defendText.setText(`${defendType}: ${defendScore}`);
         this.attackText.setText(`${attackType}: ${attackScore}`);
 
-        this.applyDamage(10);
+        const diceToResolve = this.getDiceInPlay();
+        const finishResolution = () => {
+            this.applyDamage(10);
+            this.resetGameState({ destroyDice: false });
+            this.input.enabled = true;
+            if (this.resolveButton) {
+                this.resolveButton.setAlpha(1);
+                this.resolveButton.setInteractive();
+            }
+            this.isResolving = false;
+        };
 
-        // Reset game state
-        this.resetGameState();
+        if (diceToResolve.length === 0) {
+            this.time.delayedCall(1000, finishResolution);
+            return;
+        }
+
+        Promise.all(diceToResolve.map(die => {
+            const target = this.getResolutionTarget(die);
+            return this.animateDieResolution(die, target);
+        })).then(finishResolution);
+    }
+
+    disableAllInputs() {
+        this.input.enabled = false;
+
+        if (this.rollButton) {
+            this.rollButton.disableInteractive();
+            this.rollButton.setAlpha(0.5);
+        }
+
+        if (this.sortButton) {
+            this.sortButton.disableInteractive();
+            this.sortButton.setAlpha(0.5);
+        }
+
+        if (this.resolveButton) {
+            this.resolveButton.disableInteractive();
+            this.resolveButton.setAlpha(0.5);
+        }
+    }
+
+    getDiceInPlay() {
+        const combined = [...this.defendDice, ...this.attackDice, ...this.dice];
+        return Array.from(new Set(combined));
+    }
+
+    getResolutionTarget(die) {
+        if (this.defendDice.includes(die) && this.defendZoneCenter) {
+            return this.defendZoneCenter;
+        }
+
+        if (this.attackDice.includes(die) && this.attackZoneCenter) {
+            return this.attackZoneCenter;
+        }
+
+        if (this.defendZoneCenter && this.attackZoneCenter) {
+            const midpoint = (this.defendZoneCenter.x + this.attackZoneCenter.x) / 2;
+            return die.x < midpoint ? this.defendZoneCenter : this.attackZoneCenter;
+        }
+
+        return { x: die.x, y: die.y - 100 };
+    }
+
+    animateDieResolution(die, target) {
+        return new Promise(resolve => {
+            const upwardOffset = 120;
+            const horizontalOffset = Phaser.Math.Between(-40, 40);
+
+            die.disableInteractive();
+            die.setDepth(10);
+            die.setAlpha(1);
+
+            this.tweens.timeline({
+                targets: die,
+                tweens: [
+                    {
+                        duration: 500,
+                        x: target.x + horizontalOffset,
+                        y: target.y - upwardOffset,
+                        ease: 'Cubic.easeOut'
+                    },
+                    {
+                        duration: 500,
+                        x: target.x,
+                        y: target.y,
+                        ease: 'Cubic.easeIn'
+                    }
+                ],
+                onComplete: () => {
+                    die.destroy();
+                    resolve();
+                }
+            });
+
+            this.tweens.add({
+                targets: die,
+                alpha: 0,
+                duration: 400,
+                delay: 600,
+                ease: 'Quad.easeIn'
+            });
+        });
     }
 
     applyDamage(amount) {
@@ -178,9 +285,10 @@ export class GameScene extends Phaser.Scene {
         this.healthBar.text.setText(`HP: ${this.playerHealth}/${this.playerMaxHealth}`);
     }
 
-    resetGameState() {
-        // Remove all dice
-        [...this.defendDice, ...this.attackDice, ...this.dice].forEach(d => d.destroy());
+    resetGameState({ destroyDice = true } = {}) {
+        if (destroyDice) {
+            this.getDiceInPlay().forEach(d => d.destroy());
+        }
         this.dice = [];
         this.defendDice = [];
         this.attackDice = [];
@@ -196,6 +304,10 @@ export class GameScene extends Phaser.Scene {
         this.rollButton.setInteractive();
         this.sortButton.setAlpha(0.5);
         this.sortButton.disableInteractive();
+        if (this.resolveButton) {
+            this.resolveButton.setAlpha(1);
+            this.resolveButton.setInteractive();
+        }
 
         // Reset combo highlights
         this.comboTextGroup.forEach(t => t.setColor("#ffffff"));

--- a/GameScene.js
+++ b/GameScene.js
@@ -231,40 +231,35 @@ export class GameScene extends Phaser.Scene {
 
     animateDieResolution(die, target) {
         return new Promise(resolve => {
-            const upwardOffset = 120;
-            const horizontalOffset = Phaser.Math.Between(-40, 40);
+            const upwardOffset = 180;
 
             die.disableInteractive();
             die.setDepth(10);
             die.setAlpha(1);
 
-            this.tweens.timeline({
-                targets: die,
-                tweens: [
-                    {
-                        duration: 500,
-                        x: target.x + horizontalOffset,
-                        y: target.y - upwardOffset,
-                        ease: 'Cubic.easeOut'
-                    },
-                    {
-                        duration: 500,
-                        x: target.x,
-                        y: target.y,
-                        ease: 'Cubic.easeIn'
-                    }
-                ],
-                onComplete: () => {
-                    die.destroy();
-                    resolve();
-                }
-            });
+            const inZone = this.defendDice.includes(die) || this.attackDice.includes(die);
 
+            if (inZone) {
+                // Launch any dice in zones upwards to a single point
+                this.tweens.add({
+                    targets: die,
+                    x: target.x,
+                    y: target.y - upwardOffset,
+                    duration: 500,
+                    ease: 'Cubic.easeOut',
+                    onComplete: () => {
+                        die.destroy();
+                        resolve();
+                    }
+                });
+            }
+
+            // Fade out in parallel
             this.tweens.add({
                 targets: die,
                 alpha: 0,
                 duration: 400,
-                delay: 600,
+                delay: 100,
                 ease: 'Quad.easeIn'
             });
         });

--- a/objects/Dice.js
+++ b/objects/Dice.js
@@ -7,7 +7,9 @@ export function createDie(scene, slotIndex) {
     const y = CONSTANTS.GRID_Y;
     const container = scene.add.container(x, y);
 
-    const bg = scene.add.rectangle(0, 0, CONSTANTS.DIE_SIZE, CONSTANTS.DIE_SIZE, 0x444444).setOrigin(0.5);
+    const bg = scene.add.rectangle(0, 0, CONSTANTS.DIE_SIZE, CONSTANTS.DIE_SIZE, 0x444444)
+        .setOrigin(0.5)
+        .setStrokeStyle(2, 0xffffff, 0.35);
     container.add(bg);
     container.bg = bg;
 

--- a/objects/DiceZone.js
+++ b/objects/DiceZone.js
@@ -8,17 +8,22 @@ export function setupZones(scene) {
     const zoneY = 350;
 
     // --- Defend zone ---
-    const defendZone = scene.add.zone(200, zoneY, zoneWidth, zoneHeight).setRectangleDropZone(zoneWidth, zoneHeight);
-    scene.add.rectangle(200, zoneY, zoneWidth, zoneHeight).setStrokeStyle(2, 0x3498db);
-    scene.add.text(200, zoneY - zoneHeight/2 - 20, "DEFEND", { fontSize: "24px", color: "#3498db" }).setOrigin(0.5);
+    const defendZoneX = 200;
+    const attackZoneX = 600;
+
+    const defendZone = scene.add.zone(defendZoneX, zoneY, zoneWidth, zoneHeight).setRectangleDropZone(zoneWidth, zoneHeight);
+    scene.add.rectangle(defendZoneX, zoneY, zoneWidth, zoneHeight).setStrokeStyle(2, 0x3498db);
+    scene.add.text(defendZoneX, zoneY - zoneHeight/2 - 20, "DEFEND", { fontSize: "24px", color: "#3498db" }).setOrigin(0.5);
 
     // --- Attack zone ---
-    const attackZone = scene.add.zone(600, zoneY, zoneWidth, zoneHeight).setRectangleDropZone(zoneWidth, zoneHeight);
-    scene.add.rectangle(600, zoneY, zoneWidth, zoneHeight).setStrokeStyle(2, 0xe74c3c);
-    scene.add.text(600, zoneY - zoneHeight/2 - 20, "ATTACK", { fontSize: "24px", color: "#e74c3c" }).setOrigin(0.5);
+    const attackZone = scene.add.zone(attackZoneX, zoneY, zoneWidth, zoneHeight).setRectangleDropZone(zoneWidth, zoneHeight);
+    scene.add.rectangle(attackZoneX, zoneY, zoneWidth, zoneHeight).setStrokeStyle(2, 0xe74c3c);
+    scene.add.text(attackZoneX, zoneY - zoneHeight/2 - 20, "ATTACK", { fontSize: "24px", color: "#e74c3c" }).setOrigin(0.5);
 
     scene.defendZone = defendZone;
     scene.attackZone = attackZone;
+    scene.defendZoneCenter = { x: defendZoneX, y: zoneY };
+    scene.attackZoneCenter = { x: attackZoneX, y: zoneY };
 
     // After drawing the defend zone rectangle
     scene.defendHighlight = scene.add.rectangle(200, zoneY, zoneWidth, zoneHeight, 0x3498db, 0.3).setOrigin(0.5);

--- a/objects/UI.js
+++ b/objects/UI.js
@@ -36,6 +36,7 @@ export function setupButtons(scene) {
     resolveButton.on("pointerdown", () => {
         scene.resolveDice();
     });
+    scene.resolveButton = resolveButton;
 }
 
 export function setupHealthBar(scene) {

--- a/systems/ComboSystem.js
+++ b/systems/ComboSystem.js
@@ -11,7 +11,7 @@ export const COMBO_POINTS = {
     "Straight Penta": 15,
     "Straight Quad": 10,
     "Straight Tri": 5,
-    "No valid combo": 0
+    "No combo": 0
 };
 
 export function evaluateCombo(diceArray) {
@@ -61,8 +61,8 @@ export function evaluateCombo(diceArray) {
         }
     }
 
-    // --- No valid combo ---
-    return { type: "No valid combo" };
+    // --- No combo ---
+    return { type: "No combo" };
 }
 
 export function scoreCombo(comboType) {


### PR DESCRIPTION
## Summary
- add a thin stroked border around each die to improve readability
- animate dice resolution by arcing toward zone centers, fading out, and blocking input until complete
- defer game-state reset and button re-enabling until the animation finishes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e55419fb8083269389f4ab9511c40e