### PR TITLE
Add Hotfix enemy and burn status effect

### DIFF
--- a/GameScene.js
+++ b/GameScene.js
@@ -62,7 +62,6 @@ export class GameScene extends Phaser.Scene {
             color: '#ffb347',
             fontStyle: 'bold'
         }).setVisible(false);
-        this.playerBurnText.setShadow(0, 0, '#ff6b6b', 16, true, true);
         this.updateBurnUI();
 
         // --- Enemy ---
@@ -544,14 +543,13 @@ export class GameScene extends Phaser.Scene {
             const burnY = bounds.y + bounds.height / 2;
             this.playerBurnText.setPosition(burnX, burnY);
             this.playerBurnText.setOrigin(0, 0.5);
-            this.playerBurnText.setText(`🔥 Burn ${this.playerBurn}`);
+            this.playerBurnText.setText(`Burn ${this.playerBurn}`);
             this.playerBurnText.setVisible(true);
 
             if (!this.playerBurnGlowTween) {
                 this.playerBurnGlowTween = this.tweens.add({
                     targets: this.playerBurnText,
                     alpha: { from: 0.7, to: 1 },
-                    scale: { from: 1, to: 1.05 },
                     duration: 800,
                     ease: 'Sine.easeInOut',
                     yoyo: true,

--- a/enemies/Hotfix.js
+++ b/enemies/Hotfix.js
@@ -1,21 +1,21 @@
 export class HotfixEnemy {
     constructor() {
         this.name = 'Hotfix';
-        this.maxHealth = 100;
+        this.maxHealth = 75;
         this.health = this.maxHealth;
         this.moveIndex = 0;
         this.scalingBurnValue = 3;
         this.moves = [
             {
                 key: 'apply_burn',
-                label: 'Deploy Patch: Apply 3 Burn',
+                label: `Burn ${this.scalingBurnValue + 2}`,
                 actions: [
-                    { type: 'burn', value: 3 }
+                    { type: 'burn', value: this.scalingBurnValue + 1 }
                 ]
             },
             {
                 key: 'heal_attack',
-                label: 'Quick Fix: Heal 10 + Attack 5',
+                label: 'Heal 10 + Attack 5',
                 actions: [
                     { type: 'heal', value: 10 },
                     { type: 'attack', value: 5 }
@@ -23,7 +23,7 @@ export class HotfixEnemy {
             },
             {
                 key: 'burn_defend_loop',
-                label: 'Firewall Update: Growing Burn + Defend 5',
+                label: `Burn ${this.scalingBurnValue} + Defend 10`,
                 createActions: () => {
                     const burnValue = this.scalingBurnValue;
                     this.scalingBurnValue += 1;

--- a/enemies/Hotfix.js
+++ b/enemies/Hotfix.js
@@ -1,0 +1,70 @@
+export class HotfixEnemy {
+    constructor() {
+        this.name = 'Hotfix';
+        this.maxHealth = 100;
+        this.health = this.maxHealth;
+        this.moveIndex = 0;
+        this.scalingBurnValue = 3;
+        this.moves = [
+            {
+                key: 'apply_burn',
+                label: 'Deploy Patch: Apply 3 Burn',
+                actions: [
+                    { type: 'burn', value: 3 }
+                ]
+            },
+            {
+                key: 'heal_attack',
+                label: 'Quick Fix: Heal 10 + Attack 5',
+                actions: [
+                    { type: 'heal', value: 10 },
+                    { type: 'attack', value: 5 }
+                ]
+            },
+            {
+                key: 'burn_defend_loop',
+                label: 'Firewall Update: Growing Burn + Defend 5',
+                createActions: () => {
+                    const burnValue = this.scalingBurnValue;
+                    this.scalingBurnValue += 1;
+                    return [
+                        { type: 'burn', value: burnValue },
+                        { type: 'defend', value: 5 }
+                    ];
+                }
+            }
+        ];
+    }
+
+    isDefeated() {
+        return this.health <= 0;
+    }
+
+    takeDamage(amount) {
+        this.health = Math.max(0, this.health - amount);
+    }
+
+    heal(amount) {
+        if (amount <= 0) {
+            return;
+        }
+        this.health = Math.min(this.maxHealth, this.health + amount);
+    }
+
+    getNextMove() {
+        if (this.moves.length === 0) {
+            return null;
+        }
+
+        const move = this.moves[this.moveIndex % this.moves.length];
+        this.moveIndex++;
+
+        const actions = typeof move.createActions === 'function' ? move.createActions() : move.actions;
+
+        return {
+            key: `${move.key}_${this.moveIndex}`,
+            label: move.label,
+            actions
+        };
+    }
+}

--- a/systems/EnemySystem.js
+++ b/systems/EnemySystem.js
@@ -4,7 +4,7 @@ import { HotfixEnemy } from '../enemies/Hotfix.js';
 export class EnemyManager {
     constructor() {
         // this.enemies = [new SlapperEnemy(), new LockjawEnemy()];
-        this.enemies = [new LockjawEnemy(), new HotfixEnemy()];
+        this.enemies = [new HotfixEnemy(), new LockjawEnemy()];
         this.currentEnemyIndex = 0;
         this.currentEnemy = this.enemies[this.currentEnemyIndex] || null;
         this.upcomingMove = null;

--- a/systems/EnemySystem.js
+++ b/systems/EnemySystem.js
@@ -1,10 +1,10 @@
-import { SlapperEnemy } from '../enemies/Slapper.js';
 import { LockjawEnemy } from '../enemies/Lockjaw.js';
+import { HotfixEnemy } from '../enemies/Hotfix.js';
 
 export class EnemyManager {
     constructor() {
         // this.enemies = [new SlapperEnemy(), new LockjawEnemy()];
-        this.enemies = [new LockjawEnemy()];
+        this.enemies = [new LockjawEnemy(), new HotfixEnemy()];
         this.currentEnemyIndex = 0;
         this.currentEnemy = this.enemies[this.currentEnemyIndex] || null;
         this.upcomingMove = null;


### PR DESCRIPTION
## Summary
- add the Hotfix enemy to the encounter queue with a scaling burn-focused moveset
- implement a persistent burn status that damages the player each resolve and can be mitigated by block
- surface player burn stacks next to the health display with a subtle glow effect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e250f67083269032f68866826906